### PR TITLE
Add message share pie chart

### DIFF
--- a/i18n.ts
+++ b/i18n.ts
@@ -76,6 +76,9 @@ const resources = {
       Stats: {
         title: 'Message Statistics per Person',
       },
+      MessageSharePieChart: {
+        title: "Message Share per Person",
+      },
       AggregatePerTimePlot: {
         title: 'Aggregated Messages per',
       },
@@ -151,6 +154,9 @@ const resources = {
       },
       Stats: {
         title: 'Nachrichtenstatistik pro Person',
+      },
+      MessageSharePieChart: {
+        title: 'Nachrichtenanteil pro Person',
       },
       BarChartComp: {
         title: ' pro Person',

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -24,6 +24,7 @@ import SentimentWordsPlot from './components/plots/SentimentWord';
 import Stats from './components/plots/Stats';
 import Timeline from './components/plots/Timeline';
 import WordCount from './components/plots/WordCount';
+import MessageSharePieChart from './components/plots/MessageSharePieChart';
 
 ////////////////////// Dummy Context ////////////////////////
 // This dummy context provides all necessary fields for testing.
@@ -242,6 +243,25 @@ describe('WordCount', () => {
       () => {
         const divElement = container.querySelector('div#word-count-chart');
         expect(divElement).toBeTruthy();
+      },
+      { timeout: 5000 },
+    );
+  });
+});
+
+////////////////////// Test: MessageSharePieChart ////////////////////////
+describe('MessageSharePieChart', () => {
+  it('should render the SVG element after loading (and a short timeout)', async () => {
+    const { container } = render(
+      <ChatContext.Provider value={dummyContextValue}>
+        <MessageSharePieChart />
+      </ChatContext.Provider>,
+    );
+
+    await waitFor(
+      () => {
+        const svgElement = container.querySelector('svg');
+        expect(svgElement).toBeTruthy();
       },
       { timeout: 5000 },
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import BarChartComp from './components/plots/BarChartComp';
 import SentimentWord from './components/plots/SentimentWord';
 import ChordDiagram from './components/plots/ChordDiagram';
 import HeatmapMonthWeekday from './components/plots/Heatmap';
+import MessageSharePieChart from './components/plots/MessageSharePieChart';
 import FileUploadMobile from './components/FileUploadMobile';
 import NewFileUploader from './components/FileUpload';
 import WelcomeScreen from './components/WelcomeScreen';
@@ -231,6 +232,7 @@ const App: React.FC = () => {
               <ChordDiagram />
               <WordCount />
               <Stats />
+              <MessageSharePieChart />
               <Sentiment />
               <SentimentWord />
               <HeatmapMonthWeekday />

--- a/src/components/plots/MessageSharePieChart.tsx
+++ b/src/components/plots/MessageSharePieChart.tsx
@@ -1,0 +1,110 @@
+////////////// Imports ////////////////
+import { FC, useEffect, useMemo, useRef } from 'react';
+import * as d3 from 'd3';
+import { useChat } from '../../context/ChatContext';
+import useResizeObserver from '../../hooks/useResizeObserver';
+import { useTranslation } from 'react-i18next';
+import '../../../i18n';
+
+////////////// Component: MessageSharePieChart ////////////////
+/**
+ * Displays a pie chart showing the share of messages per participant.
+ */
+const MessageSharePieChart: FC = () => {
+  const { filteredMessages, darkMode, metadata, useShortNames } = useChat();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const dimensions = useResizeObserver(containerRef);
+  const { t } = useTranslation();
+
+  // Aggregate message counts per sender
+  const data = useMemo(() => {
+    const counts: Record<string, number> = {};
+    filteredMessages.forEach((msg) => {
+      counts[msg.sender] = (counts[msg.sender] || 0) + 1;
+    });
+    return Object.entries(counts).map(([sender, count]) => ({ sender, count }));
+  }, [filteredMessages]);
+
+  // Color scale for senders
+  const color = useMemo(() => {
+    const scheme = darkMode ? d3.schemeSet2 : d3.schemeCategory10;
+    return d3.scaleOrdinal<string, string>(scheme).domain(data.map((d) => d.sender));
+  }, [data, darkMode]);
+
+  // D3 Pie rendering
+  useEffect(() => {
+    if (!dimensions) return;
+    const width = dimensions.width || 0;
+    const height = dimensions.height || 0;
+    const radius = Math.min(width, height) / 2 - 10;
+    const svg = d3.select(svgRef.current);
+
+    svg.selectAll('*').remove();
+    const g = svg
+      .attr('width', width)
+      .attr('height', height)
+      .append('g')
+      .attr('transform', `translate(${width / 2}, ${height / 2})`);
+
+    const pie = d3.pie<{ sender: string; count: number }>().value((d) => d.count);
+    const arc = d3.arc<d3.PieArcDatum<{ sender: string; count: number }>>()
+      .innerRadius(0)
+      .outerRadius(radius);
+
+    const arcs = g.selectAll('path').data(pie(data)).enter().append('path');
+    arcs
+      .attr('d', arc as any)
+      .attr('fill', (d) => color(d.data.sender))
+      .attr('stroke', darkMode ? '#111' : '#fff')
+      .attr('stroke-width', 1);
+
+    // Labels
+    const labelArc = d3.arc<d3.PieArcDatum<{ sender: string; count: number }>>()
+      .innerRadius(radius * 0.6)
+      .outerRadius(radius * 0.6);
+
+    g.selectAll('text')
+      .data(pie(data))
+      .enter()
+      .append('text')
+      .attr('transform', (d) => `translate(${labelArc.centroid(d)})`)
+      .attr('text-anchor', 'middle')
+      .attr('alignment-baseline', 'middle')
+      .style('font-size', '12px')
+      .style('fill', darkMode ? 'white' : 'black')
+      .text((d) => {
+        const sender = d.data.sender;
+        const label = useShortNames && metadata?.sendersShort[sender]
+          ? metadata.sendersShort[sender]
+          : sender;
+        const percentage = ((d.data.count / d3.sum(data, (dd) => dd.count)) * 100).toFixed(0);
+        return `${label} (${percentage}%)`;
+      });
+  }, [data, dimensions, darkMode, color, metadata, useShortNames]);
+
+  return (
+    <div
+      id="plot-message-share-pie"
+      ref={containerRef}
+      className={`border w-full md:min-w-[300px] md:basis-[300px] p-4 flex-grow ${
+        darkMode ? 'border-gray-300 bg-gray-800 text-white' : 'border-black bg-white text-black'
+      }`}
+      style={{ minHeight: '350px', maxHeight: '550px', overflow: 'hidden' }}
+    >
+      <h2 className="text-sm md:text-lg font-semibold mb-3 md:mb-4">
+        {t('MessageSharePieChart.title')}
+      </h2>
+      <div className="flex-grow flex justify-center items-center w-full h-full">
+        {filteredMessages.length === 0 ? (
+          <span className="text-lg">{t('General.noDataAvailable')}</span>
+        ) : (
+          <svg ref={svgRef} className="w-full h-full" />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MessageSharePieChart;
+


### PR DESCRIPTION
## Summary
- implement new `MessageSharePieChart` plot component showing message share distribution
- integrate pie chart in app routing and tests
- add i18n strings for English and German

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841ec2cce6883208f5b4e7c0e0c9efa